### PR TITLE
fix Message History Context

### DIFF
--- a/src/service/chat/history.ts
+++ b/src/service/chat/history.ts
@@ -70,11 +70,15 @@ const formatMessageToChatHistory = (message: Message) => {
   }
 };
 
+/**
+ * Constructs a chat history array from the last N messages, where N is determined by CONTEXT_WINDOW_MESSAGES.
+ * This function focuses on recent messages for context relevance.
+ */
 export const constructMessageHistory = (messages: Message[]) => {
   const list: ChatHistory[] = [];
   const messageWindow = messages.slice(-CONTEXT_WINDOW_MESSAGES)
   for (let index = 0; index < messageWindow.length; index++) {
-    const message = messages[index];
+    const message = messageWindow[index];
     const chat = formatMessageToChatHistory(message);
     if (chat) list.push(chat);
   }

--- a/src/service/chat/history.ts
+++ b/src/service/chat/history.ts
@@ -75,12 +75,8 @@ const formatMessageToChatHistory = (message: Message) => {
  * This function focuses on recent messages for context relevance.
  */
 export const constructMessageHistory = (messages: Message[]) => {
-  const list: ChatHistory[] = [];
-  const messageWindow = messages.slice(-CONTEXT_WINDOW_MESSAGES)
-  for (let index = 0; index < messageWindow.length; index++) {
-    const message = messageWindow[index];
-    const chat = formatMessageToChatHistory(message);
-    if (chat) list.push(chat);
-  }
-  return list;
+  return messages
+    .slice(-CONTEXT_WINDOW_MESSAGES) // Focus on the last N messages
+    .map(formatMessageToChatHistory) // Transform each message
+    .filter(Boolean); // Remove any null or undefined entries
 };


### PR DESCRIPTION
**Issue**
Currently, we only use the first `N` messages of
the chat history instead of the last `N`.

**Details**
In the `constructMessageHistory` function,
the loop incorrectly iterates over indexes based
on the original `messages` array rather than the
`messageWindow` slice. To fix this and correctly
 process the last `N` messages, the loop should
 iterate over `messageWindow`  instead.

**Fix**
That's what I fix with 81ca8bf55f0b07dca405fd72f819f3652ca1154f.
Then, with a16fb258d15cfc994a5d8a8e7084d672b445d7e7, I refactored the related code
to make it less error-prone, potentially avoiding
issues as the one described here.