### PR TITLE
feat: add explicit OpenAI fallback mode with clean TypeScript propagation

### DIFF
--- a/src/config/chatAPI-config.ts
+++ b/src/config/chatAPI-config.ts
@@ -15,7 +15,8 @@ export const guidelines = {
   UNRELATED_QUESTION: `If the question is not related to the context, say this phrase EXACTLY '${ERROR_MESSAGES.NO_ANSWER}'`,
   LINKING: `DO NOT explicity mention the existence of the context provided, however, references can and should be made to the links provided in the context e.g '[0]'.`,
   FOLLOW_UP_QUESTIONS: 'If you have an answer, generate four relevant follow up questions, do not include introductory text about follow-up questions. Each question must be in this format: `--{{ what problems did segwit solve }}--` in a new line.',
-  USED_SOURCES: `Lastly, list all sources relevant in generating the answer in a list in this format '__sources__: [LINK_INDICES_HERE]'`
+  USED_SOURCES: `Lastly, list all sources relevant in generating the answer in a list in this format '__sources__: [LINK_INDICES_HERE]'`,
+  FALLBACK_INSTRUCTION: `You are an AI assistant providing helpful answers to user queries. Answer the user's question directly and concisely without using any external context or search results. You must rely on your own internal knowledge to generate the response.`,
 };
 
 export const CONTEXT_WINDOW_MESSAGES = 6

--- a/src/service/chat/history.ts
+++ b/src/service/chat/history.ts
@@ -3,14 +3,20 @@ import { separateLinksFromApiMessage } from "@/utils/links";
 import { CONTEXT_WINDOW_MESSAGES, guidelines } from "@/config/chatAPI-config";
 import { ChatHistory } from "@/types";
 
-const buildSystemMessage = (question: string, context: string) => {
+const buildSystemMessage = (question: string, context: string, fallback?: boolean) => {
   const {
     BASE_INSTRUCTION,
     NO_ANSWER,
     UNRELATED_QUESTION,
     FOLLOW_UP_QUESTIONS,
     LINKING,
+    FALLBACK_INSTRUCTION,
   } = guidelines;
+
+  if (fallback) {
+    return `${FALLBACK_INSTRUCTION}`;
+  }
+
   return `${BASE_INSTRUCTION}\n${NO_ANSWER}\n${UNRELATED_QUESTION}\n${context}\n${LINKING}\n${FOLLOW_UP_QUESTIONS}`;
 };
 
@@ -19,13 +25,15 @@ export const buildChatMessages = ({
   context,
   oldContext,
   messages,
+  fallback,
 }: {
   question: string;
   context: string;
   oldContext?: string;
   messages: ChatHistory[];
+  fallback?: boolean;
 }) => {
-  const systemMessage = buildSystemMessage(question, context);
+  const systemMessage = buildSystemMessage(question, context, fallback);
   return [
     {
       role: "system",


### PR DESCRIPTION
This PR adds an explicit fallback mode that allows querying OpenAI directly when source-based answers are unavailable or unsatisfactory.

When fallback is enabled:
	•	Retrieval, ranking, and citation logic are bypassed.
	•	The system queries OpenAI directly.
	•	The response is clearly marked as unsourced and potentially inaccurate.

Default behavior remains unchanged, and the fallback is only activated when explicitly requested.
No new files were added, and changes are limited to the minimal code paths required.

Fixes  #96
